### PR TITLE
Improve install safeguards

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,27 @@ set -e
 APP_NAME="devobox"
 TARGET_CONFIG_DIR="$HOME/.config/$APP_NAME"
 TARGET_BIN_DIR="$HOME/.local/bin"
+BACKUP_DIR="${TARGET_CONFIG_DIR}.bak"
+
+FORCE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --force)
+            FORCE=true
+            ;;
+        -h|--help)
+            echo "Uso: ./install.sh [--force]"
+            echo "  --force  Sobrescreve configuração existente sem perguntar"
+            exit 0
+            ;;
+        *)
+            echo "⚠️  Argumento desconhecido: $arg"
+            echo "Uso: ./install.sh [--force]"
+            exit 1
+            ;;
+    esac
+done
 
 echo "🚀 Instalando $APP_NAME..."
 
@@ -12,9 +33,25 @@ if ! command -v podman &> /dev/null; then
     exit 1
 fi
 
+if [ -d "$TARGET_CONFIG_DIR" ]; then
+    if [ "$FORCE" = false ]; then
+        echo "⚠️  Uma configuração existente foi encontrada em $TARGET_CONFIG_DIR."
+        read -rp "Deseja sobrescrever? (y/N) " CONFIRM
+        if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
+            echo "ℹ️ Instalação abortada. Reexecute com --force para sobrescrever ou remova $TARGET_CONFIG_DIR."
+            exit 1
+        fi
+    fi
+
+    echo "🗂️  Criando backup em $BACKUP_DIR..."
+    rm -rf "$BACKUP_DIR"
+    cp -a "$TARGET_CONFIG_DIR" "$BACKUP_DIR"
+fi
+
 echo "📂 Configurando diretório em $TARGET_CONFIG_DIR..."
+rm -rf "$TARGET_CONFIG_DIR"
 mkdir -p "$TARGET_CONFIG_DIR"
-cp -r config/* "$TARGET_CONFIG_DIR/"
+cp -a config/. "$TARGET_CONFIG_DIR/"
 
 echo "🔗 Criando link simbólico em $TARGET_BIN_DIR..."
 mkdir -p "$TARGET_BIN_DIR"
@@ -25,6 +62,11 @@ ln -sf "$TARGET_CONFIG_DIR/devobox" "$TARGET_BIN_DIR/$APP_NAME"
 echo "🏗️  Executando build inicial dos containers..."
 cd "$TARGET_CONFIG_DIR"
 make build
+
+if [[ ":$PATH:" != *":$TARGET_BIN_DIR:"* ]]; then
+    echo "⚠️  $TARGET_BIN_DIR não está no seu PATH. Adicione com:"
+    echo "    export PATH=\"$TARGET_BIN_DIR:$PATH\""
+fi
 
 echo ""
 echo "✅ Instalação concluída com sucesso!"


### PR DESCRIPTION
## Summary
- add argument parsing to support --force and helpful usage output
- create a backup of existing configuration before overwriting during installation
- warn when ~/.local/bin is not on PATH and provide the export command

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f46a0ba88322af73fdcb0a38c109)