### PR TITLE
Add dynamic database configuration via databases.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,22 +364,13 @@ devobox rebuild
 
 ### Adicionar Novos Bancos de Dados
 
-1. Edite `~/.config/devobox/Makefile` e adicione:
+1. Edite `~/.config/devobox/databases.conf` e adicione uma linha no formato `nome|imagem|ports|variaveis_de_ambiente`:
 
-```makefile
-@echo "🔥 Criando MongoDB (Parado)..."
-@podman create --name mongodb \
-    -p 27017:27017 \
-    docker.io/mongo:7
+```
+mongodb|docker.io/mongo:7|27017:27017|
 ```
 
-2. Edite `~/.config/devobox/devobox` e atualize:
-
-```bash
-DATABASES=("postgres" "redis" "mongodb")
-```
-
-3. Reconstrua:
+2. Reconstrua:
 
 ```bash
 devobox rebuild

--- a/bin/devobox
+++ b/bin/devobox
@@ -10,8 +10,35 @@ YELLOW='\033[0;33m'
 RED='\033[0;31m'
 NC='\033[0m'
 
-# Available databases list
-DATABASES=("postgres" "redis")
+# Available databases list (loaded dinamically)
+DATABASES=()
+
+load_databases() {
+    local config_file="$CONFIG_DIR/databases.conf"
+
+    if [ ! -f "$config_file" ]; then
+        echo -e "${RED}❌ Arquivo de bancos não encontrado em $config_file${NC}"
+        exit 1
+    fi
+
+    DATABASES=()
+
+    while IFS='|' read -r name _; do
+        name=$(echo "$name" | xargs)
+
+        if [ -z "$name" ] || [[ "$name" == \#* ]]; then
+            continue
+        fi
+
+        DATABASES+=("$name")
+    done < "$config_file"
+
+    if [ ${#DATABASES[@]} -eq 0 ]; then
+        echo -e "${YELLOW}⚠️  Nenhum banco configurado em $config_file${NC}"
+    fi
+}
+
+load_databases
 CONTAINERS=("devobox" "${DATABASES[@]}")
 
 show_help() {
@@ -25,8 +52,8 @@ show_help() {
     echo "  status              -> Mostra containers"
     echo "  rebuild             -> Reconstrói a imagem"
     echo ""
-    echo "Bancos de dados:"
-    echo "  db start [service]  -> Inicia todos os bancos ou um específico (postgres|redis)"
+    echo "Bancos de dados (definidos em databases.conf):"
+    echo "  db start [service]  -> Inicia todos os bancos ou um específico"
     echo "  db stop [service]   -> Para todos os bancos ou um específico"
     echo "  db restart [service]-> Reinicia todos os bancos ou um específico"
     echo "  db status           -> Status dos bancos"
@@ -96,6 +123,11 @@ stop_database() {
 }
 
 start_all_dbs() {
+    if [ ${#DATABASES[@]} -eq 0 ]; then
+        echo -e "${YELLOW}⚠️  Nenhum banco configurado para iniciar.${NC}"
+        return
+    fi
+
     echo -e "${BLUE}🔌 Iniciando todos os bancos...${NC}"
     for db in "${DATABASES[@]}"; do
         start_database "$db"
@@ -103,6 +135,11 @@ start_all_dbs() {
 }
 
 stop_all_dbs() {
+    if [ ${#DATABASES[@]} -eq 0 ]; then
+        echo -e "${YELLOW}⚠️  Nenhum banco configurado para parar.${NC}"
+        return
+    fi
+
     echo -e "${BLUE}💤 Parando todos os bancos...${NC}"
     for db in "${DATABASES[@]}"; do
         stop_database "$db"
@@ -117,6 +154,11 @@ restart_database() {
 }
 
 restart_all_dbs() {
+    if [ ${#DATABASES[@]} -eq 0 ]; then
+        echo -e "${YELLOW}⚠️  Nenhum banco configurado para reiniciar.${NC}"
+        return
+    fi
+
     echo -e "${BLUE}🔄 Reiniciando todos os bancos...${NC}"
     for db in "${DATABASES[@]}"; do
         restart_database "$db"
@@ -125,6 +167,12 @@ restart_all_dbs() {
 
 show_db_status() {
     echo -e "${BLUE}📊 Status dos bancos:${NC}"
+
+    if [ ${#DATABASES[@]} -eq 0 ]; then
+        echo -e "  ${YELLOW}○${NC} Nenhum banco configurado em $CONFIG_DIR/databases.conf"
+        return
+    fi
+
     for db in "${DATABASES[@]}"; do
         if check_running "$db"; then
             echo -e "  ${GREEN}●${NC} $db (rodando)"
@@ -215,7 +263,7 @@ case "$1" in
                 ;;
             *)
                 echo -e "${RED}❌ Subcomando inválido para 'db'${NC}"
-                echo "Uso: devobox db {start|stop|restart|status} [postgres|redis]"
+                echo "Uso: devobox db {start|stop|restart|status} [serviço]"
                 exit 1
                 ;;
         esac
@@ -229,7 +277,7 @@ case "$1" in
 
     down|stop)
         echo -e "${BLUE}💤 Parando ambiente...${NC}"
-        podman stop devobox postgres redis >/dev/null 2>&1 || true
+        podman stop devobox "${DATABASES[@]}" >/dev/null 2>&1 || true
         echo -e "${GREEN}✅ Tudo parado.${NC}"
         ;;
 

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,3 +1,7 @@
+.SHELLFLAGS := -eu -o pipefail -c
+SHELL := /bin/bash
+DB_CONF ?= databases.conf
+
 .PHONY: all build clean
 
 all: build
@@ -6,18 +10,39 @@ build:
 	@echo "🏗️  Construindo imagem Devobox (Arch)..."
 	@podman build -t devobox-img -f Containerfile .
 
-	@echo "🐘 Criando Postgres (Parado)..."
-	@podman rm -f postgres 2>/dev/null || true
-	@podman create --name postgres \
-		-p 5432:5432 \
-		-e POSTGRES_USER=dev -e POSTGRES_PASSWORD=devpass -e POSTGRES_DB=dev_default \
-		docker.io/postgres:16
-
-	@echo "⚡ Criando Redis (Parado)..."
-	@podman rm -f redis 2>/dev/null || true
-	@podman create --name redis \
-		-p 6379:6379 \
-		docker.io/redis:7-alpine
+	@echo "🗄️  Lendo bancos de dados em $(DB_CONF)..."
+	@if [ ! -f "$(DB_CONF)" ]; then \
+		echo "❌ Arquivo $(DB_CONF) não encontrado"; \
+		exit 1; \
+	fi
+	@while IFS='|' read -r name image ports env_vars; do \
+		name="$$(echo $$name | xargs)"; \
+		image="$$(echo $$image | xargs)"; \
+		ports="$$(echo $$ports | xargs)"; \
+		env_vars="$$(echo $$env_vars | xargs)"; \
+		if [ -z "$$name" ] || [[ "$$name" == \#* ]]; then \
+			continue; \
+		fi; \
+		echo "🧹 Removendo $$name (se existir)..."; \
+		podman rm -f "$$name" 2>/dev/null || true; \
+		create_args=""; \
+		if [ -n "$$ports" ]; then \
+			IFS=',' read -ra port_list <<< "$$ports"; \
+			for port in "$${port_list[@]}"; do \
+				port="$${port// /}"; \
+				[ -n "$$port" ] && create_args="$$create_args -p $$port"; \
+			done; \
+		fi; \
+		if [ -n "$$env_vars" ]; then \
+			IFS=',' read -ra env_list <<< "$$env_vars"; \
+			for env_var in "$${env_list[@]}"; do \
+				env_var="$${env_var// /}"; \
+				[ -n "$$env_var" ] && create_args="$$create_args -e $$env_var"; \
+			done; \
+		fi; \
+		echo "📦 Criando $$name (Parado)..."; \
+		podman create --name "$$name" $$create_args "$$image"; \
+	done < "$(DB_CONF)"
 
 	@echo "📦 Criando Container Devobox (Parado)..."
 	@podman rm -f devobox 2>/dev/null || true

--- a/config/databases.conf
+++ b/config/databases.conf
@@ -1,0 +1,10 @@
+# Formato: nome|imagem|ports|variaveis_de_ambiente
+# - ports: lista separada por vírgulas no formato HOST:CONTAINER
+# - variaveis_de_ambiente: lista separada por vírgulas no formato CHAVE=valor
+# Linhas em branco ou iniciadas com # serão ignoradas
+
+# Postgres padrão
+postgres|docker.io/postgres:16|5432:5432|POSTGRES_USER=dev,POSTGRES_PASSWORD=devpass,POSTGRES_DB=dev_default
+
+# Redis padrão
+redis|docker.io/redis:7-alpine|6379:6379|


### PR DESCRIPTION
## Summary
- add a databases.conf template to define databases with ports and environment variables
- update the devobox CLI to load database services dynamically and handle empty configurations
- change the build Makefile to create database containers from databases.conf and document the new workflow

## Testing
- bash -n bin/devobox

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ffb2a52c83228962180af716295e)