### PR TITLE
Stop devobox and databases after shell exit

### DIFF
--- a/bin/devobox
+++ b/bin/devobox
@@ -233,6 +233,11 @@ case "$1" in
         # Test if directory exists in container, fallback to default
         podman exec devobox test -d "$WORK_DIR" 2>/dev/null || WORK_DIR="/home/dev/code"
         podman exec -it -w "$WORK_DIR" devobox bash
+        exit_code=$?
+        echo -e "${BLUE}💤 Encerrando Devobox e bancos após sair do shell...${NC}"
+        stop_all_dbs
+        podman stop devobox >/dev/null 2>&1 || true
+        exit $exit_code
         ;;
 
     db)


### PR DESCRIPTION
## Summary
- stop databases as well when exiting the interactive devobox shell
- keep shutting down the devobox container while preserving the shell exit code

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221fd151488322af04eed7825ce90c)